### PR TITLE
Fix a mistake in generation of CER sequences.

### DIFF
--- a/eval_functions.py
+++ b/eval_functions.py
@@ -7,7 +7,7 @@ def parse_krn_content(krn, ler_parsing=False, cer_parsing=False):
         tokens = krn.split(" ")
         characters = []
         for token in tokens:
-            if token not in ['<b>', '<t>']:
+            if token in ['<b>', '<t>']:
                 characters.append(token)
             else:
                 for char in token:


### PR DESCRIPTION
Hi all,

I think the code for generating the sequences for CER is mistaken. Originally, you had
```python
            if token not in ['<b>', '<t>']:
                characters.append(token)
            else:
                for char in token:
                    characters.append(char)
```
which means that for input "2·BBB\t8·dd", you would create characters `["2·BBB", "<", "t", ">", "8·dd"]`.

If the condition on the first line is flipped, you would get `["2", "·", "B", "B", "B", "<t>", "8", "·", "d", "d"]`, which seems more like what you would want. (But according to paper, I had the feeling that CER should consider symbols `["2", "·", "BBB", "<t>", "8", "·", "dd"]`, but that is probably just my bad understanding.)

Thanks for clarification and cheers!